### PR TITLE
Improved router definition

### DIFF
--- a/DependencyInjection/CompilerPass/EventBusCompilerPass.php
+++ b/DependencyInjection/CompilerPass/EventBusCompilerPass.php
@@ -79,8 +79,8 @@ final class EventBusCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param bool             $asyncBus
      * @param bool             $passThrough
-     * @param string $distribution
-     * @param array $middlewares
+     * @param string           $distribution
+     * @param array            $middlewares
      *
      * @return void
      */
@@ -102,8 +102,8 @@ final class EventBusCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param array            $asyncAdapter
      * @param bool             $passThrough
-     * @param array $routes
-     * @param array $exchanges
+     * @param array            $routes
+     * @param array            $exchanges
      *
      * @return void
      */
@@ -128,8 +128,8 @@ final class EventBusCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param array            $asyncAdapter
      * @param bool             $passThrough
-     * @param array $routes
-     * @param array $exchanges
+     * @param array            $routes
+     * @param array            $exchanges
      *
      * @return void
      */
@@ -228,8 +228,8 @@ final class EventBusCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $container
      * @param bool             $asyncBus
      * @param bool             $passThrough
-     * @param string $distribution
-     * @param array $middlewares
+     * @param string           $distribution
+     * @param array            $middlewares
      */
     private static function createEventBus(
         ContainerBuilder $container,
@@ -261,15 +261,14 @@ final class EventBusCompilerPass implements CompilerPassInterface
      * Create inline event bus.
      *
      * @param ContainerBuilder $container
-     * @param string $distribution
-     * @param array $middlewares
+     * @param string           $distribution
+     * @param array            $middlewares
      */
     private static function createInlineEventBus(
         ContainerBuilder $container,
         string $distribution,
         array $middlewares
-    )
-    {
+    ) {
         $container->setDefinition('drift.inline_event_bus', (new Definition(
             InlineEventBus::class, [
                 new Reference(LoopInterface::class),
@@ -295,7 +294,7 @@ final class EventBusCompilerPass implements CompilerPassInterface
      * @param ContainerBuilder $containerr
      * @param bool             $isAsync
      * @param bool             $passthrough
-     * @param array $definedMiddlewares
+     * @param array            $definedMiddlewares
      *
      * @return array
      */

--- a/Router/Router.php
+++ b/Router/Router.php
@@ -35,11 +35,6 @@ final class Router
     private $exchanges;
 
     /**
-     * first exchange.
-     */
-    private $firstExchange;
-
-    /**
      * Router constructor.
      *
      * @param string[] $routes
@@ -57,7 +52,6 @@ final class Router
 
         $this->routes = $routes;
         $this->exchanges = $exchanges;
-        $this->firstExchange = array_key_first($exchanges);
     }
 
     /**
@@ -79,7 +73,17 @@ final class Router
         $eventLastPart = end($eventParts);
         $routes = $this->routes;
 
-        $exchangeAlias = $routes[get_class($event)] ?? $routes[$eventLastPart] ?? $this->firstExchange;
+        $exchangeAlias =
+            $routes['_all'] ??
+            $routes[get_class($event)] ??
+            $routes[$eventLastPart] ??
+            $routes['_others'] ??
+            null;
+
+        if (is_null($exchangeAlias)) {
+            return [];
+        }
+
         $exchangeAliases = explode(',', $exchangeAlias);
 
         return array_map(function (string $exchangeAlias) {

--- a/Tests/Async/AsyncAdapterTest.php
+++ b/Tests/Async/AsyncAdapterTest.php
@@ -51,6 +51,7 @@ abstract class AsyncAdapterTest extends EventBusFunctionalTest
                 Event1::class => 'events_internal1',
                 Event2::class => 'events_internal1, events_internal2',
                 Event3::class => 'events_internal2',
+                '_others' => 'events_internal1',
             ],
             'exchanges' => [
                 'events_internal1' => 'events1',

--- a/Tests/Router/RouterTest.php
+++ b/Tests/Router/RouterTest.php
@@ -52,13 +52,108 @@ class RouterTest extends TestCase
         ]);
         $this->assertEquals('real_exchange', $router->getExchangeByAlias('exchange1'));
         $this->assertEquals('real_exchange2', $router->getExchangeByAlias('exchange2'));
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event1('')));
+        $this->assertEquals([], $router->getExchangesByEvent(new Event2('')));
+        $this->assertEquals(['real_exchange', 'real_exchange2'], $router->getExchangesByEvent(new Event3('')));
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event1(''))));
+        $this->assertEquals([], $router->getExchangesByEvent(new DomainEventEnvelope(new Event2(''))));
+        $this->assertEquals(['real_exchange', 'real_exchange2'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event3(''))));
+    }
+
+    /**
+     * Test with matching all.
+     */
+    public function testWithMatchingAll()
+    {
+        $router = new Router([
+            '_all' => 'exchange1',
+            Event1::class => 'exchange1',
+            Event3::class => 'exchange1, exchange2',
+            '_others' => 'exchange2',
+        ], [
+            'exchange1' => 'real_exchange',
+            'exchange2' => 'real_exchange2',
+        ]);
+
         $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event1('')));
         $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event2('')));
-        $this->assertEquals(['real_exchange', 'real_exchange2'], $router->getExchangesByEvent(new Event3('')));
-        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(
-            new Event2('')
-        )));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event3('')));
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event1(''))));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event2(''))));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event3(''))));
     }
+
+    /**
+     * Test with matching only all.
+     */
+    public function testWithMatchingOnlyAll()
+    {
+        $router = new Router([
+            '_all' => 'exchange1',
+        ], [
+            'exchange1' => 'real_exchange',
+            'exchange2' => 'real_exchange2',
+        ]);
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event1('')));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event2('')));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event3('')));
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event1(''))));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event2(''))));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event3(''))));
+    }
+
+    /**
+     * Test with others.
+     */
+    public function testWithMatchingOthers()
+    {
+        $router = new Router([
+            Event1::class => 'exchange1',
+            Event3::class => 'exchange1, exchange2',
+            '_others' => 'exchange2',
+        ], [
+            'exchange1' => 'real_exchange',
+            'exchange2' => 'real_exchange2',
+        ]);
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event1('')));
+        $this->assertEquals(['real_exchange2'], $router->getExchangesByEvent(new Event2('')));
+        $this->assertEquals(['real_exchange', 'real_exchange2'], $router->getExchangesByEvent(new Event3('')));
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event1(''))));
+        $this->assertEquals(['real_exchange2'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event2(''))));
+        $this->assertEquals(['real_exchange', 'real_exchange2'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event3(''))));
+    }
+
+    /**
+     * Test with only others.
+     */
+    public function testWithMatchingOnlyOthers()
+    {
+        $router = new Router([
+            '_others' => 'exchange1',
+        ], [
+            'exchange1' => 'real_exchange',
+            'exchange2' => 'real_exchange2',
+        ]);
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event1('')));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event2('')));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new Event3('')));
+
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event1(''))));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event2(''))));
+        $this->assertEquals(['real_exchange'], $router->getExchangesByEvent(new DomainEventEnvelope(new Event3(''))));
+    }
+
+    /**
+     * Test matching the event name.
+     */
 
     /**
      * Test with router.


### PR DESCRIPTION
- for enrouting all events into one/several exchanges, use `_all`
- for enrouting missing events into one/several exchanges, use
`_missing`
- If both are missing, non-defined events will not be dispatched
asynchronously